### PR TITLE
Update stereo demo for Jetson CSI cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ pip install opencv-python Pillow
 ## Running the demo
 
 Execute the `stereo_demo.py` script. By default it tries to open `/dev/video0` and `/dev/video1`.
+If you are using CSI cameras on a Jetson, pass the full GStreamer pipeline for each camera:
 
 ```bash
-python3 stereo_demo.py
+python3 stereo_demo.py \
+  "nvarguscamerasrc sensor-id=0 ! video/x-raw(memory:NVMM), width=1280, height=720, framerate=30/1 ! nvvidconv ! video/x-raw, format=BGRx ! videoconvert ! appsink" \
+  "nvarguscamerasrc sensor-id=1 ! video/x-raw(memory:NVMM), width=1280, height=720, framerate=30/1 ! nvvidconv ! video/x-raw, format=BGRx ! videoconvert ! appsink"
 ```
 
 You will see a window with two tabs:


### PR DESCRIPTION
## Summary
- add utility to build a Jetson CSI GStreamer pipeline
- open sources using CAP_GSTREAMER when a pipeline string is supplied
- document pipeline usage for Jetson cameras in the README

## Testing
- `python3 -m py_compile stereo_demo.py`


------
https://chatgpt.com/codex/tasks/task_b_6868705b61748328b82a62ac4b606b4d