### PR TITLE
Add simple stereo viewer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Install the Python dependencies with:
 pip install opencv-python Pillow
 ```
 
-## Running the demo
+## Running the demos
+
+### Tkinter demo
 
 Execute the `stereo_demo.py` script. By default it tries to open `/dev/video0` and `/dev/video1`.
 If you are using CSI cameras on a Jetson, pass the full GStreamer pipeline for each camera:
@@ -33,3 +35,14 @@ You will see a window with two tabs:
 * **Stereo View** – displays a live feed from both cameras next to each other.
 
 Snapshots are saved in the current directory with a timestamped filename.
+
+### Simple OpenCV viewer
+
+For a minimal example without Tkinter, run `simple_stereo.py` with the same arguments. It shows both
+streams side by side in an OpenCV window. Press **q** to quit.
+
+```bash
+python3 simple_stereo.py 0 1
+```
+
+Replace `0` and `1` with the appropriate GStreamer pipelines when using CSI cameras.

--- a/simple_stereo.py
+++ b/simple_stereo.py
@@ -1,0 +1,45 @@
+import cv2
+import argparse
+
+
+def open_capture(src):
+    """Open a camera source. Supports numeric indices and GStreamer pipelines."""
+    if isinstance(src, int) or (isinstance(src, str) and src.isdigit()):
+        return cv2.VideoCapture(int(src))
+    return cv2.VideoCapture(src, cv2.CAP_GSTREAMER)
+
+
+def main(left_source, right_source):
+    left_cap = open_capture(left_source)
+    right_cap = open_capture(right_source)
+
+    if not left_cap.isOpened() or not right_cap.isOpened():
+        print("Failed to open one or both cameras")
+        return
+
+    while True:
+        ret_left, frame_left = left_cap.read()
+        ret_right, frame_right = right_cap.read()
+        if not (ret_left and ret_right):
+            print("Frame grab failed")
+            break
+
+        combined = cv2.hconcat([frame_left, frame_right])
+        cv2.imshow("Stereo View", combined)
+
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    left_cap.release()
+    right_cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simple stereo viewer")
+    parser.add_argument('left', nargs='?', default='0',
+                        help='Left camera index or GStreamer pipeline')
+    parser.add_argument('right', nargs='?', default='1',
+                        help='Right camera index or GStreamer pipeline')
+    args = parser.parse_args()
+    main(args.left, args.right)


### PR DESCRIPTION
## Summary
- add a minimal OpenCV-based stereo viewer script `simple_stereo.py`
- update README to document the new script and usage

## Testing
- `python3 -m py_compile stereo_demo.py simple_stereo.py`


------
https://chatgpt.com/codex/tasks/task_b_68687451602883288fefcca298313e0c