### PR TITLE
Automatically open CSI cameras with Argus pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ pip install opencv-python Pillow
 
 ### Tkinter demo
 
-Execute the `stereo_demo.py` script. By default it tries to open `/dev/video0` and `/dev/video1`.
-If you are using CSI cameras on a Jetson, pass the full GStreamer pipeline for each camera:
+Execute the `stereo_demo.py` script. When numeric camera IDs are provided, the
+script now automatically opens the Jetson CSI cameras using the
+`nvarguscamerasrc` pipeline:
+
+```bash
+python3 stereo_demo.py 0 1
+```
+
+You can still pass full GStreamer pipelines if you need custom settings:
 
 ```bash
 python3 stereo_demo.py \

--- a/stereo_demo.py
+++ b/stereo_demo.py
@@ -24,6 +24,10 @@ def gstreamer_pipeline(sensor_id=0,
 
 def open_capture(source):
     if isinstance(source, int) or (isinstance(source, str) and source.isdigit()):
+        pipeline = gstreamer_pipeline(sensor_id=int(source))
+        cap = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+        if cap.isOpened():
+            return cap
         return cv2.VideoCapture(int(source))
     return cv2.VideoCapture(source, cv2.CAP_GSTREAMER)
 


### PR DESCRIPTION
## Summary
- open Jetson CSI cameras automatically in `stereo_demo.py`
- document automatic pipeline use in README

## Testing
- `python3 -m py_compile simple_stereo.py stereo_demo.py`

------
https://chatgpt.com/codex/tasks/task_b_686877e1c5bc8328a3010d0c51dda20e